### PR TITLE
Fixed a 'BAD Invalid field-name' bug that in some cases could occur

### DIFF
--- a/custom_from/custom_from.php
+++ b/custom_from/custom_from.php
@@ -38,7 +38,7 @@ class	custom_from extends rcube_plugin
 		foreach ($rules as $header => $value)
 		{
 			if (!isset ($excludes[$header]))
-				$params['fetch_headers'] = $params['fetch_headers'] . ' ' . $header;
+				$params['fetch_headers'] = trim($params['fetch_headers'] . ' ' . $header);
 		}
 
 		return $params;


### PR DESCRIPTION
Fixed an imap bug that in some cases could occur ('BAD Invalid field-name in UID Fetch BODY.PEEK[HEADER.FIELDS' due to field-names being separated by 2 spaces) because of which no messages will be listed.

[16-Apr-2014 16:23:00 +0100]: [0095] C: A0008 UID FETCH 1:25 (UID RFC822.SIZE FLAGS INTERNALDATE BODY.PEEK[HEADER.FIELDS (DATE FROM TO SUBJECT CONTENT-TYPE CC REPLY-TO LIST-POST DISPOSITION-NOTIFICATION-TO X-PRIORITY  X-ORIGINAL-TO)])
[16-Apr-2014 16:23:00 +0100]: [0095] S: A0008 BAD Invalid field-name in UID Fetch BODY.PEEK[HEADER.FIELDS
