### PR TITLE
Reset $address before finding best possible match

### DIFF
--- a/custom_from/custom_from.php
+++ b/custom_from/custom_from.php
@@ -146,6 +146,7 @@ class	custom_from extends rcube_plugin
 				}
 
 				// Find best possible match from recipients and identities
+				$address = null;
 				$score = 0;
 
 				foreach ($recipients as $email => $recipient)


### PR DESCRIPTION
Otherwise $address contains an array with latest values of the "Decode recipients and matching rules from retrieved addresses"-loop. You will see "Array" instead of an address in the gui, if no best possible match is found.
