### PR TITLE
Don't add angle brackets to the header information

### DIFF
--- a/custom_from/custom_from.php
+++ b/custom_from/custom_from.php
@@ -111,7 +111,7 @@ class	custom_from extends rcube_plugin
 							break;
 
 						default:
-							$addresses = isset ($headers->others[$header]) ? $IMAP->decode_address_list ('<' . $headers->others[$header] . '>') : array ();
+							$addresses = isset ($headers->others[$header]) ? $IMAP->decode_address_list ($headers->others[$header]) : array ();
 
 							break;
 					}


### PR DESCRIPTION
If we add angle brackets to values before calling decode_address_list the result will be broken if the values allready have angle brackets. decode_address_list can handle values with and without angle brackets so there is not need to add them. (Tested with several header informations)
