### PR TITLE
Avoid overiding values extracted form different headers 

### DIFF
--- a/custom_from/custom_from.php
+++ b/custom_from/custom_from.php
@@ -121,8 +121,9 @@ class	custom_from extends rcube_plugin
 					{
 						if (isset ($address['mailto']))
 						{
-							$recipients[$address['mailto']] = array
+							$recipients[] = array
 							(
+								'mailto'		=> $address['mailto'],
 								'domain'		=> preg_replace ('/^[^@]*@(.*)$/', '$1', $address['mailto']),
 								'match_domain'	=> strpos ($rule, 'd') !== false,
 								'match_exact'	=> strpos ($rule, 'e') !== false,
@@ -149,8 +150,10 @@ class	custom_from extends rcube_plugin
 				$address = null;
 				$score = 0;
 
-				foreach ($recipients as $email => $recipient)
+				foreach ($recipients as $recipient)
 				{
+					$email = $recipient['mailto'];
+					
 					// Relevance score 3: exact match found in identities
 					if ($score < 3 && $recipient['match_exact'] && isset ($identities[$email]))
 					{


### PR DESCRIPTION
If the same mailto is extracted from diffent parts of the header, the settings from the last extraction overrides any other extraction.

Example say you have
`$rcmail_config['custom_from_header_rules'] = 'Envelope-To=deo;to=de';`
And the header contains
`To: me@bar.com
...
Envelope-To: me@bar.com`
And your domain is `foo.com`
The address me@bar.com will not be choosen because the settings for me@bar.com will both be saved in `$recipients['me@bar.com']` with the one for the To-Header overriding the one for the Envelope-To-Header. That results in not taking me@bar.com becaues `$recipients['me@bar.com']['match_other']` will be false.
