### PR TITLE
Allow case-insensitive domain matching

### DIFF
--- a/custom_from/custom_from.php
+++ b/custom_from/custom_from.php
@@ -170,7 +170,7 @@ class	custom_from extends rcube_plugin
 					{
 						foreach ($identities as $identity)
 						{
-							if ($identity['domain'] === $recipient['domain'])
+							if (strcasecmp($identity['domain'], $recipient['domain']) == 0)
 							{
 								$address = $identity['name'] ? ($identity['name'] . ' <' . $email . '>') : $email;
 								$score = 2;


### PR DESCRIPTION
Sometimes emails are sent with the To: address in upper case.  In this case, if the user's identities are in lower case, then the domain will currently fail to match.
